### PR TITLE
Allow optional passing of pattern argument to ALPR service

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,11 @@ openALPR:
   #   "us" => United States
   #   "vn2" => Vietnam Two Line
   country_code: 'us'
+  # Attempts to match the plate number against a plate pattern
+  # (e.g. md for Maryland, ca for California)
+  # OpenALPR supports the following pattern codes based on the selected country
+  # See: https://github.com/openalpr/openalpr/tree/master/runtime_data/postprocess
+  pattern: 'ca' # optional
 
 # Record detected license plate information
 recorders:

--- a/lib/OpenALPRDetect.js
+++ b/lib/OpenALPRDetect.js
@@ -8,11 +8,13 @@ export const DEFAULT_COUNTRY_CODE = 'us';
 export default class OpenALPRDetect {
 	#url = null;
 	#countryCode = null;
+	#pattern = null;
 
-	constructor(url, countryCode) {
+	constructor(url, countryCode, pattern = null) {
 		
 		this.url = url;
 		this.countryCode = countryCode;
+		this.pattern = pattern;
 	}
 	get url() {
 		return this.#url;
@@ -30,10 +32,20 @@ export default class OpenALPRDetect {
 			throw new TypeError('countryCode must be a string.');
 		this.#countryCode = v;
 	}
+	get pattern() {
+		return this.#pattern;
+	}
+	set pattern(v) {
+		if(v == null) return;
+		if(typeof v !== 'string')
+			throw new TypeError('pattern must be a string.');
+		this.#pattern = v;
+	}
 	async detect(rawImage) {
 		const formData  = new FormData();
 		formData.append('upload', new Blob([await rawImage.toJpegBuffer()]));
 		formData.append('country_code', this.countryCode);
+		if (this.pattern !== null) formData.append('pattern', this.pattern);
 
 		const response = await fetch(this.#url.href, {
 			method: 'POST',
@@ -74,7 +86,8 @@ export default class OpenALPRDetect {
 			throw new TypeError('config must be an Object.');
 		return new this(
 			new URL(config.url),
-			config.countryCode || DEFAULT_COUNTRY_CODE
+			config.countryCode || DEFAULT_COUNTRY_CODE,
+			config.pattern
 		);
 	}
 }

--- a/lib/OpenALPRDetect.js
+++ b/lib/OpenALPRDetect.js
@@ -36,8 +36,7 @@ export default class OpenALPRDetect {
 		return this.#pattern;
 	}
 	set pattern(v) {
-		if(v == null) return;
-		if(typeof v !== 'string')
+		if(v !== null && typeof v !== 'string')
 			throw new TypeError('pattern must be a string.');
 		this.#pattern = v;
 	}


### PR DESCRIPTION
This PR adds the ability to pass a `pattern` argument in the `openALPR` section of `config.yaml`. This argument is optional. When provided it is passed to the `open-alpr-http-wrapper` via body params.

Open to feedback and suggestions. Tried to follow existing patterns. https://github.com/sclaflin/OpenALPR-HTTP-Wrapper/pull/3 would need to be merged for this to be supported